### PR TITLE
change function getProperty to accept the metadata instead of the con…

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   },
   "dependencies": {
     "bulk-require": "^0.2.1",
-    "nmr-metadata": "^1.0.0"
+    "nmr-metadata": "^1.1.0"
   }
 }

--- a/src/types/sample/nmr.js
+++ b/src/types/sample/nmr.js
@@ -18,13 +18,13 @@ module.exports = {
         });
     },
 
-    getProperty(filename, content) {
+    getProperty(filename, metaData) {
         const extension = common.getExtension(filename);
         if(extension === 'jdx' || extension === 'dx') {
-            if(isFid.test(filename)) {
+            if(metaData && metaData.isFid) {
                 return 'jcampFID';
             }
-            if(isFt.test(filename)) {
+            if(metaData && metaData.isFt) {
                 return 'jcampFT';
             }
             return 'jcamp';


### PR DESCRIPTION
@stropitek, can you check if you can include this change:

 Use the isFid and isFt from metadata to determine the property.
 nmr-metadata v1.1.0

To close #2
